### PR TITLE
Triggered arm limits when too close to stage

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -33,6 +33,20 @@ public final class Constants {
         public static final double armManualScale = 0.1;
     }
 
+    public static class FieldConstants {
+
+        public static final double fieldLength = Units.feetToMeters(54.27);
+        public static final double fieldWidth = Units.feetToMeters(26.9375);
+
+        public static final Translation2d blueStageCenter =
+                new Translation2d(Units.inchesToMeters(156.895), fieldWidth / 2);
+        public static final Translation2d redStageCenter =
+                new Translation2d(fieldLength - Units.inchesToMeters(157.395), fieldWidth / 2);
+
+        public static final double stageDangerRadius = Units.inchesToMeters(85.9 / 2 + 12)
+                + SwerveConstants.PhysicalConstants.driveBaseRadius;
+    }
+
     public static class SwerveConstants {
         public static class ModuleConstants {
             public static final double wheelDiameterMeters = Units.inchesToMeters(4);
@@ -176,6 +190,7 @@ public final class Constants {
 
         public static final double frontLimit = 0.0;
         public static final double backLimit = 1.58;
+        public static final double underStageLimit = 0.2;
 
         public static final double gearRatio = 1.0 / 256.0; // 256:1.
                                                                 // Make sure both numbers are doubles (x.0, not just x)

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -6,6 +6,8 @@
 package frc.robot;
 
 import edu.wpi.first.math.MathUtil;
+import edu.wpi.first.math.Pair;
+import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.Command;
@@ -23,6 +25,8 @@ import frc.robot.subsystems.DriveSubsystem;
 import frc.robot.subsystems.ExampleSubsystem;
 import frc.robot.subsystems.IntakeSubsystem;
 import frc.robot.subsystems.LauncherSubsystem;
+
+import java.util.ArrayList;
 
 
 /**
@@ -51,6 +55,22 @@ public class RobotContainer {
     public RobotContainer() {
         // Configure the trigger bindings
         configureBindings();
+
+        var underStageArmConstraints = new ArrayList<Pair<Rotation2d, Rotation2d>>(1);
+        underStageArmConstraints.add(
+                Pair.of(Rotation2d.fromRadians(0), Rotation2d.fromRadians(Constants.ArmConstants.underStageLimit)));
+
+        new Trigger(() -> driveSubsystem.getPose().getTranslation().getDistance(Constants.FieldConstants.blueStageCenter)
+                    < Constants.FieldConstants.stageDangerRadius)
+            .or(() -> driveSubsystem.getPose().getTranslation().getDistance(Constants.FieldConstants.redStageCenter)
+                    < Constants.FieldConstants.stageDangerRadius)
+            .onTrue(
+                Commands.runOnce(() -> armSubsystem.setArmRotationConstraints(underStageArmConstraints,
+                        new Trigger(() -> driveSubsystem.getPose().getTranslation().getDistance(Constants.FieldConstants.blueStageCenter)
+                                > Constants.FieldConstants.stageDangerRadius)
+                            .and(() -> driveSubsystem.getPose().getTranslation().getDistance(Constants.FieldConstants.redStageCenter)
+                                > Constants.FieldConstants.stageDangerRadius)
+            ), armSubsystem));
 
         SmartDashboard.putData(driveSubsystem);
         SmartDashboard.putData(armSubsystem);


### PR DESCRIPTION
Created a trigger that checks whether the robot has moved into the
danger zone around the stage and should limit the arm, removing these
limits when it clears the same radius.