### PR TITLE
Fix pose reporting again

### DIFF
--- a/src/main/deploy/pathplanner/autos/DS1@S Do Nothing.auto
+++ b/src/main/deploy/pathplanner/autos/DS1@S Do Nothing.auto
@@ -1,0 +1,18 @@
+{
+  "version": 1.0,
+  "startingPose": {
+    "position": {
+      "x": 0.75,
+      "y": 4.3
+    },
+    "rotation": -60.0
+  },
+  "command": {
+    "type": "sequential",
+    "data": {
+      "commands": []
+    }
+  },
+  "folder": null,
+  "choreoAuto": false
+}

--- a/src/main/deploy/pathplanner/autos/DS2@S Do Nothing.auto
+++ b/src/main/deploy/pathplanner/autos/DS2@S Do Nothing.auto
@@ -1,0 +1,18 @@
+{
+  "version": 1.0,
+  "startingPose": {
+    "position": {
+      "x": 1.4485159727387908,
+      "y": 5.551241224320246
+    },
+    "rotation": 0
+  },
+  "command": {
+    "type": "sequential",
+    "data": {
+      "commands": []
+    }
+  },
+  "folder": null,
+  "choreoAuto": false
+}

--- a/src/main/deploy/pathplanner/autos/DS3@S Do Nothing.auto
+++ b/src/main/deploy/pathplanner/autos/DS3@S Do Nothing.auto
@@ -1,0 +1,18 @@
+{
+  "version": 1.0,
+  "startingPose": {
+    "position": {
+      "x": 0.75,
+      "y": 6.75
+    },
+    "rotation": 60.0
+  },
+  "command": {
+    "type": "sequential",
+    "data": {
+      "commands": []
+    }
+  },
+  "folder": null,
+  "choreoAuto": false
+}

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -71,7 +71,8 @@ public class RobotContainer {
 
         registerAutonomousCommands();
 
-        autonomousCommand = AutoBuilder.buildAutoChooser("");
+        int driverStationNumber = DriverStation.getLocation().orElse(2);
+        autonomousCommand = AutoBuilder.buildAutoChooser("DS" + driverStationNumber + "@S Do Nothing");
 
         configureDashboard();
 
@@ -179,8 +180,6 @@ public class RobotContainer {
                 () -> -driverController.getRightX(),
                 () -> !driverController.getHID().getYButton() // Switch to robot oriented when Y is held
         ));
-
-        driverController.x().whileTrue(driveSubsystem.getPathPlannerFollowCommand("Super Simple", true));
 
         // set the arm subsystem to run the "runAutomatic" function continuously when no other command is running
         armSubsystem.setDefaultCommand(new RunCommand(armSubsystem::runAutomatic, armSubsystem));

--- a/src/main/java/frc/robot/subsystems/DriveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/DriveSubsystem.java
@@ -23,7 +23,6 @@ import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import frc.lib.LimelightHelpers;
-import frc.robot.Constants;
 import frc.robot.Constants.SwerveConstants;
 
 import java.util.Arrays;
@@ -170,16 +169,11 @@ public class DriveSubsystem extends SubsystemBase {
      * Events, if registered elsewhere using {@link com.pathplanner.lib.auto.NamedCommands}, will be run.
      *
      * @param pathName The PathPlanner path name, as configured in the configuration
-     * @param setOdomToStart If true, will set the odometry to the start of the path when this command is initialized
      * @return {@link AutoBuilder#followPath(PathPlannerPath)} path command
      */
-    public Command getPathPlannerFollowCommand(String pathName, boolean setOdomToStart) {
+    public Command getPathPlannerFollowCommand(String pathName) {
         // Loads the path from the GUI name given
         PathPlannerPath path = PathPlannerPath.fromPathFile(pathName);
-
-        if (setOdomToStart) {
-            resetOdometry(new Pose2d(path.getPoint(0).position, getGyroRotation2d()));
-        }
 
         // Creates a path following command using AutoBuilder. This will execute any named commands when running
         return AutoBuilder.followPath(path);


### PR DESCRIPTION
Pathing was messing with pose resetting because it wasn't flipping the start position. Now, an autonomous should be run before anything to properly reset the robot pose. A few were added as defaults to just reset the position and do nothing else for this purpose.

Now the robot pose is reliant on an autonomous being run to reset the robot position before driving. This should help address flipping behavior, since now the robot knows its actual angle rather than just fighting between the Limelight being accurate and the gyro still reading 0° at startup.
